### PR TITLE
Bugfix: WXstrip.setPixelColor

### DIFF
--- a/wordclock_tools/WXstrip.py
+++ b/wordclock_tools/WXstrip.py
@@ -101,6 +101,13 @@ class WXstrip():
         #os._exit(1)
     
     def setPixelColor(self, index, color):
+        # color is 24bit RGB
+        b = int(color & 0xFF)
+        g = int((color >> 8) & 0xFF)
+        r = int((color >> 16) & 0xFF)
+
+        color = Color(r, g, b)
+
         self.colors[int(index)] = color
         #if(self.w != None):
             


### PR DESCRIPTION
Hi Pascal,

I tried to run your code in dev mode and received the following error 

```
File ".../wordclock/rpi_wordclock_python3/wordclock_tools/WXstrip.py", line 113, in update
    label.SetForegroundColour((color.r,color.g,color.b, self.brightness)) # set text color
AttributeError: 'int' object has no attribute 'r'
```

This is due to the color parameter of WXstrip.setPixelColor being a 24 bit integer. However, self.colors values should be a WXcolors.Color instance. 


