### PR TITLE
Further fixes

### DIFF
--- a/fontdemo.py
+++ b/fontdemo.py
@@ -54,7 +54,7 @@ class Bitmap(object):
     def bitblt(self, src, x, y):
         """Copy all pixels from `src` into this bitmap"""
         srcpixel = 0
-        dstpixel = y * self.width + x
+        dstpixel = int(y * self.width + x)
         row_offset = self.width - src.width
 
         for sy in range(src.height):

--- a/fontdemo.py
+++ b/fontdemo.py
@@ -36,10 +36,11 @@ class Bitmap(object):
     of a single pixel in the bitmap. A value of 0 indicates that the pixel is `off`
     and any other value indicates that it is `on`.
     """
+
     def __init__(self, width, height, pixels=None):
-        self.width = width
-        self.height = height
-        self.pixels = pixels or bytearray(width * height)
+        self.width = int(width)
+        self.height = int(height)
+        self.pixels = pixels or bytearray(self.width * self.height)
 
     def __repr__(self):
         """Return a string representation of the bitmap's pixels."""

--- a/wordclock_interfaces/web_interface.py
+++ b/wordclock_interfaces/web_interface.py
@@ -136,10 +136,11 @@ class Color(Resource):
     def get(self):
         default_plugin = web_interface.app.wclk.plugins[web_interface.app.wclk.default_plugin]
 
-        if web_interface.app.wclk.developer_mode_active:
-            channel_wise = lambda x: {'red': x.r, 'green': x.g, 'blue': x.b}
-        else:
-            channel_wise = lambda x: {'blue': x & 255, 'green': (x >> 8) & 255, 'red': (x >> 16) & 255}
+        # if web_interface.app.wclk.developer_mode_active:
+        #    def channel_wise(x): return {'red': x.r, 'green': x.g, 'blue': x.b}
+        # else:
+        def channel_wise(x): return {'blue': x & 255, 'green': (
+            x >> 8) & 255, 'red': (x >> 16) & 255}
 
         return {
             'background': channel_wise(default_plugin.bg_color),

--- a/wordclock_plugins/snake/plugin.py
+++ b/wordclock_plugins/snake/plugin.py
@@ -20,6 +20,8 @@ class plugin:
         '''
         # Get plugin name (according to the folder, it is contained in)
         self.name = os.path.dirname(__file__).split('/')[-1]
+        self.pretty_name = "Snake"
+        self.description = "Play the snake game on the wordclock"
 
     def updatePoints(self, sn, wcd):
         points = sn.data["points"]

--- a/wordclock_plugins/snake/plugin.py
+++ b/wordclock_plugins/snake/plugin.py
@@ -189,7 +189,7 @@ class plugin:
         wcd.show()
         if (sn.data["isGameOver"] == True):
             for i in range(3):
-                wcd.clearLetters(wcc.BLACK)
+                wcd.setColorToAll(wcc.BLACK, includeMinutes=False)
                 wcd.show()
                 time.sleep(0.3)
                 self.drawSnakeBoard(sn, wcd)

--- a/wordclock_plugins/time_as_words_german/time_as_words_german.py
+++ b/wordclock_plugins/time_as_words_german/time_as_words_german.py
@@ -34,8 +34,8 @@ class time_as_words_german():
         self.full_hour_suffix = " UHR"
 
     def get_time(self, time, withPrefix=True):
-        hour=time.hour%12+(1 if time.minute//5 > 4 else 0)
-        minute=time.minute//5
+        hour = int(time.hour % 12+(1 if time.minute//5 > 4 else 0))
+        minute = int(time.minute//5)
         # Assemble string
         return str(
             (self.prefix if withPrefix else "") +

--- a/wordclock_plugins/time_in_seconds/plugin.py
+++ b/wordclock_plugins/time_in_seconds/plugin.py
@@ -51,7 +51,7 @@ class plugin:
         # Set background color
         wcd.setColorToAll(self.bg_color, includeMinutes=True)
         #show seconds based on numbers defined in time_seconds
-        for i in range(110, -1, -110/11):
+        for i in range(110, -1, -110//11):
             #previous seconds, dimming down
             taw_indices = self.taw.get_time(currentSecond-1 if currentSecond != 0 else 59)
             wcd.setColorBy1DCoordinates(wcd.strip, taw_indices, wcc.Color(i, i, i))

--- a/wordclock_tools/wordclock_display.py
+++ b/wordclock_tools/wordclock_display.py
@@ -44,8 +44,8 @@ class wordclock_display:
         if config.getboolean('wordclock', 'developer_mode'):
             from .WXstrip import WXstrip
             self.strip = WXstrip(wci)
-            self.default_font = os.path.join('/usr/share/fonts/TTF/',
-                                             config.get('wordclock_display', 'default_font') + '.ttf')
+            # self.default_font = os.path.join('/usr/share/fonts/TTF/',
+            #                                 config.get('wordclock_display', 'default_font') + '.ttf')
             # from GTKstrip import GTKstrip
             # self.strip = GTKstrip(wci)
             # self.default_font = 'wcfont.ttf'
@@ -53,19 +53,20 @@ class wordclock_display:
             try:
                 from rpi_ws281x import PixelStrip, ws
                 self.strip = PixelStrip(self.wcl.LED_COUNT, self.wcl.LED_PIN, self.wcl.LED_FREQ_HZ,
-                                               self.wcl.LED_DMA, self.wcl.LED_INVERT, max_brightness , 0,
-                                               ws.WS2811_STRIP_GRB)
+                                        self.wcl.LED_DMA, self.wcl.LED_INVERT, max_brightness, 0,
+                                        ws.WS2811_STRIP_GRB)
             except:
                 print('Update deprecated external dependency rpi_ws281x. '
                       'For details see also https://github.com/jgarff/rpi_ws281x/blob/master/python/README.md')
-                      
-            self.default_font = os.path.join('/usr/share/fonts/truetype/freefont/',
-                                             config.get('wordclock_display', 'default_font') + '.ttf')
 
-            if config.get('wordclock_display', 'default_font') == 'wcfont':
-                self.default_font =  self.base_path + '/wcfont.ttf'
-            else:
-                self.default_font = os.path.join('/usr/share/fonts/truetype/freefont/', config.get('wordclock_display', 'default_font') + '.ttf')
+        if config.get('wordclock_display', 'default_font') == 'wcfont':
+            self.default_font = self.base_path + '/wcfont.ttf'
+        else:
+            self.default_font = os.path.join(
+                '/usr/share/fonts/truetype/freefont/', config.get('wordclock_display', 'default_font') + '.ttf')
+
+        if not os.path.exists(self.default_font):
+            raise ValueError("Font does not exist: %s" % self.default_font)
 
         # Initialize the NeoPixel object
         self.strip.begin()

--- a/wordclock_tools/wordclock_display.py
+++ b/wordclock_tools/wordclock_display.py
@@ -257,6 +257,8 @@ class wordclock_display:
         text_width, text_height, text_max_descent = fnt.text_dimensions(text)
         text_as_pixel = fnt.render_text(text)
 
+        text_width = int(text_width)
+
         # Display text count times
         for i in range(count):
 


### PR DESCRIPTION
Hi there!

This PR is about some issues related to:
- floats where there should be ints
- Snake plugin: missing pretty name and description
- font not set properly

@phenze is there any plan to get your changes merged back into the main repository (bk1285/rpi_wordclock)?

Now, all plugins (except weather) can be activated. Known issues
- Displaying seconds plugin: only the first number is displayed correctly
- Snake game plugin: when the snake hits the wall on the left, an exception related to buttons is raised (I don't know if this happens on a RPi as well)
- Weather plugin is broken (due to pywapi not being available on Python 3.8). I already fixed that (next PR)